### PR TITLE
Update to use node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: true
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'
 branding:
   icon: 'layers'


### PR DESCRIPTION
# Description

This updates the action to use `Node.js v16`. Fixes Issue #15.

## Issues Resolved

Fixes GitHub Actions annotation warnings:

```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actionshub/test-kitchen@main. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

## Check List

- [X] New functionality has been tested.
- [X] New functionality has been documented in the README if applicable.
