### PR TITLE
Update to use Node.js 20.x (current LTS)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: true
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'
 branding:
   icon: 'layers'


### PR DESCRIPTION
# Description

This updates the action to use Node.js v20. 

## Issues Resolved

- Fixes GitHub Actions annotation warning:
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actionshub/test-kitchen@main. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```
## Check List

- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
